### PR TITLE
feat: add rerenderOnTokenRefresh prop to ReactKeycloakProvider

### DIFF
--- a/packages/core/src/provider.tsx
+++ b/packages/core/src/provider.tsx
@@ -58,6 +58,13 @@ export type AuthProviderProps<T extends AuthClient> = {
    * @param {AuthClientTokens} tokens The current AuthClient tokens set.
    */
   onTokens?: (tokens: AuthClientTokens) => void
+
+  /**
+  * A flag to enable component rerender after token refresh. Defaults to true.
+  *
+  * @default true
+  */
+  rerenderOnTokenRefresh?: boolean
 }
 
 type AuthProviderState = {
@@ -148,7 +155,7 @@ export function createAuthProvider<T extends AuthClient>(
     }
 
     updateState = (event: AuthClientEvent) => () => {
-      const { authClient, onEvent, onTokens, isLoadingCheck } = this.props
+      const { authClient, onEvent, onTokens, isLoadingCheck, rerenderOnTokenRefresh } = this.props
       const {
         initialized: prevInitialized,
         isLoading: prevLoading,
@@ -166,7 +173,7 @@ export function createAuthProvider<T extends AuthClient>(
       if (
         !prevInitialized ||
         isLoading !== prevLoading ||
-        newToken !== prevToken
+        (newToken !== prevToken && rerenderOnTokenRefresh !== false)
       ) {
         this.setState({
           initialized: true,

--- a/packages/core/test/provider.spec.tsx
+++ b/packages/core/test/provider.spec.tsx
@@ -663,4 +663,48 @@ describe('AuthProvider', () => {
       setStateSpy.mockRestore()
     })
   })
+
+  describe('onAuthRefreshSuccess', () => {
+    it('should not update state if token is refreshed', () => {
+      const keycloakStub = createKeycloakStub()
+      const onEventListener = jest.fn()
+      const AuthProvider = createAuthProvider(keycloakCtx)
+      const setStateSpy = jest.spyOn(AuthProvider.prototype, 'setState')
+
+      rtl.render(
+        <AuthProvider
+          authClient={keycloakStub}
+          onEvent={onEventListener}
+          rerenderOnTokenRefresh={false}
+        >
+          <div />
+        </AuthProvider>
+      )
+
+      rtl.act(() => {
+        keycloakStub.idToken = 'fakeIdToken'
+        keycloakStub.refreshToken = 'fakeRefreshToken'
+        keycloakStub.token = 'fakeToken'
+
+        keycloakStub.onReady!()
+      })
+
+      rtl.act(() => {
+        keycloakStub.idToken = 'newFakeIdToken'
+        keycloakStub.refreshToken = 'newFakeRefreshToken'
+        keycloakStub.token = 'newFakeToken'
+
+        keycloakStub.onAuthRefreshSuccess!()
+      })
+
+      expect(onEventListener).toHaveBeenCalledTimes(2)
+      expect(onEventListener).toHaveBeenNthCalledWith(1, 'onReady')
+      expect(onEventListener).toHaveBeenNthCalledWith(2, 'onAuthRefreshSuccess')
+
+      expect(setStateSpy).toHaveBeenCalledTimes(1)
+
+      // Remove setStateSpy mock
+      setStateSpy.mockRestore()
+    })
+  })
 })


### PR DESCRIPTION
## Description

This disables rerender of the component when set to false
when token is refreshed. Default value is true.

Co-authored-by:  Bruno Mendola <1853562+brunomendola@users.noreply.github.com>

Fixes #97 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Test `should not update state if token is refreshed`. The test has been inspired from a similar test `should not update state twice if tokens are unchanged`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
